### PR TITLE
Fixed an issue arising in an edge case where a channel is never found standalone

### DIFF
--- a/shapley_value.py
+++ b/shapley_value.py
@@ -110,8 +110,7 @@ def calculate_shapley(df, channel_name, conv_name):
     '''
     # casting the subset into dict, and getting the unique channels
     c_values = df.set_index(channel_name).to_dict()[conv_name]
-    df['channels'] = df[channel_name].apply(lambda x: x if len(x.split(",")) == 1 else np.nan)
-    channels = list(df['channels'].dropna().unique())
+    channels = df[channel_name].apply(lambda x: x.split(",")).explode().unique()
     
     v_values = {}
     for A in power_set(channels): #generate all possible channel combination


### PR DESCRIPTION
With existing format, df is assumed to have atleast one row where the channel subset contains a single channel alone. If there exists some channels which do not have interactions as standalone, such channels are ignored.

Fixed this issue by considering explode on channels nad getting unique from there. Added advantage is that the input df is not modified, which makes it a pure function as per functional programming paradigm.